### PR TITLE
Adding several bi-lstm tagger variants examples

### DIFF
--- a/10-structured/bilstm-teacher-forcing-tagger.py
+++ b/10-structured/bilstm-teacher-forcing-tagger.py
@@ -10,6 +10,22 @@ import argparse
 import dynet as dy
 import numpy as np
 
+parser = argparse.ArgumentParser(description='BiLSTM variants.')
+parser.add_argument('--teacher', action='store_true')
+parser.add_argument('--perceptron', action='store_true')
+parser.add_argument('--hinge', action='store_true')
+
+args = parser.parse_args()
+use_teacher_forcing = args.teacher
+use_structure_perceptron = args.perceptron
+use_hinge = args.hinge
+
+print("Training BiLSTM %s teacher forcing, %s structured perceptron loss, %s margin."
+      % ("with" if use_teacher_forcing else "without",
+         "with" if use_structure_perceptron else "without",
+         "with" if use_hinge else "without")
+      )
+
 # format of files: each line is "word1|tag1 word2|tag2 ..."
 train_file = "../data/tags/train.txt"
 dev_file = "../data/tags/dev.txt"
@@ -37,6 +53,7 @@ train = list(read(train_file))
 unk_word = w2i["<unk>"]
 w2i = defaultdict(lambda: unk_word, w2i)
 unk_tag = t2i["<unk>"]
+start_tag = t2i["<start>"]
 t2i = defaultdict(lambda: unk_tag, t2i)
 nwords = len(w2i)
 ntags = len(t2i)
@@ -48,6 +65,7 @@ trainer = dy.AdamTrainer(model)
 
 # Model parameters
 EMBED_SIZE = 64
+TAG_EMBED_SIZE = 16
 HIDDEN_SIZE = 128
 
 assert HIDDEN_SIZE % 2 == 0
@@ -55,8 +73,16 @@ assert HIDDEN_SIZE % 2 == 0
 # Lookup parameters for word embeddings
 LOOKUP = model.add_lookup_parameters((nwords, EMBED_SIZE))
 
-# Word-level BiLSTM
-fwdLSTM = dy.SimpleRNNBuilder(1, EMBED_SIZE, HIDDEN_SIZE / 2, model)  # Forward LSTM
+if use_teacher_forcing:
+    TAG_LOOKUP = model.add_lookup_parameters((ntags, TAG_EMBED_SIZE))
+
+# Word-level BiLSTM is just a composition of two LSTMs.
+if use_teacher_forcing:
+    fwdLSTM = dy.SimpleRNNBuilder(1, EMBED_SIZE + TAG_EMBED_SIZE, HIDDEN_SIZE / 2, model)  # Forward LSTM
+else:
+    fwdLSTM = dy.SimpleRNNBuilder(1, EMBED_SIZE, HIDDEN_SIZE / 2, model)  # Forward LSTM
+
+# We cannot insert previous predicted tag to the backward LSTM anyway.
 bwdLSTM = dy.SimpleRNNBuilder(1, EMBED_SIZE, HIDDEN_SIZE / 2, model)  # Backward LSTM
 
 # Word-level softmax
@@ -86,6 +112,64 @@ def calc_scores(words):
     return scores
 
 
+def calc_scores_with_tags(words, tags):
+    dy.renew_cg()
+
+    last_tags = [start_tag] + tags[:-1]
+
+    word_embs = [LOOKUP[x] for x in words]
+    tag_embs = [TAG_LOOKUP[x] for x in last_tags]
+
+    input_embs = [dy.concatenate([w, t]) for w, t in zip(word_embs, tag_embs)]
+
+    # Transduce all batch elements with an LSTM
+    fwd_init = fwdLSTM.initial_state()
+    fwd_word_reps = fwd_init.transduce(input_embs)  # NOTE: We use the concatenated embeddings for the forward LSTM.
+
+    bwd_init = bwdLSTM.initial_state()
+    bwd_word_reps = bwd_init.transduce(reversed(word_embs))  # We use the original embeddings for the backward LSTM.
+
+    combined_word_reps = [dy.concatenate([f, b]) for f, b in zip(fwd_word_reps, reversed(bwd_word_reps))]
+
+    # Softmax scores
+    W = dy.parameter(W_sm)
+    b = dy.parameter(b_sm)
+    scores = [dy.affine_transform([b, W, x]) for x in combined_word_reps]
+
+    return scores
+
+
+def calc_scores_with_previous_tag(words):
+    dy.renew_cg()
+
+    word_embs = [LOOKUP[x] for x in words]
+
+    # Transduce all batch elements for the backward LSTM, using the original word embeddings.
+    bwd_init = bwdLSTM.initial_state()
+    bwd_word_reps = bwd_init.transduce(reversed(word_embs))
+
+    # Softmax scores
+    W = dy.parameter(W_sm)
+    b = dy.parameter(b_sm)
+
+    scores = []
+    # Transduce one by one for the forward LSTM
+    fwd_init = fwdLSTM.initial_state()
+    s_fwd = fwd_init
+    prev_tag = start_tag
+    for word, bwd_word_rep in zip(word_embs, reversed(bwd_word_reps)):
+        # Concatenate word and tag representation just as training.
+        fwd_input = dy.concatenate([word, TAG_LOOKUP[prev_tag]])
+        s_fwd = s_fwd.add_input(fwd_input)
+        combined_rep = dy.concatenate([s_fwd.output(), bwd_word_rep])
+        score = dy.affine_transform([b, W, combined_rep])
+        prediction = np.argmax(score)
+        prev_tag = prediction
+        scores.append(score)
+
+    return scores
+
+
 # Calculate MLE loss for one example
 def calc_loss(scores, tags):
     losses = [dy.pickneglogsoftmax(score, tag) for score, tag in zip(scores, tags)]
@@ -111,7 +195,12 @@ for ITER in range(100):
                   file=sys.stderr)
         # train on the example
         words, tags = train[sid]
-        scores = calc_scores(words)
+
+        if use_teacher_forcing:
+            scores = calc_scores_with_tags(words, tags)
+        else:
+            scores = calc_scores(words)
+
         loss_exp = calc_loss(scores, tags)
         this_correct += calc_correct(scores, tags)
         this_loss += loss_exp.scalar_value()
@@ -123,7 +212,12 @@ for ITER in range(100):
     this_sents = this_words = this_loss = this_correct = 0
     for words, tags in dev:
         this_sents += 1
-        scores = calc_scores(words)
+
+        if use_teacher_forcing:
+            scores = calc_scores_with_previous_tag(words)
+        else:
+            scores = calc_scores(words)
+
         loss_exp = calc_loss(scores, tags)
         this_correct += calc_correct(scores, tags)
         this_loss += loss_exp.scalar_value()

--- a/10-structured/bilstm-teacher-forcing-tagger.py
+++ b/10-structured/bilstm-teacher-forcing-tagger.py
@@ -69,8 +69,7 @@ def calc_scores(words):
     word_reps = LSTM.transduce([LOOKUP[x] for x in words])
 
     # Softmax scores
-    W = dy.parameter(W_sm)
-    b = dy.parameter(b_sm)
+    W, b = dy.parameter(W_sm, b_sm)
     scores = [dy.affine_transform([b, W, x]) for x in word_reps]
 
     return scores

--- a/10-structured/bilstm-variant-tagger.py
+++ b/10-structured/bilstm-variant-tagger.py
@@ -233,6 +233,12 @@ def calc_sequence_score(scores, tags):
 
 
 def hamming_augmented_decode(scores, reference):
+    """
+    Local decoding with hamming cost.
+    :param scores: Local decoding scores.
+    :param reference: Referent tag result.
+    :return:
+    """
     augmented_result = []
     for score, referent_tag in zip(scores, reference):
         origin_scores = score.npvalue()
@@ -254,6 +260,8 @@ def perceptron_loss(scores, reference):
         reference_score = calc_sequence_score(scores, reference)
         prediction_score = calc_sequence_score(scores, predictions)
         if use_cost_augmented:
+            # One could actually get the hamming augmented value during decoding, but we didn't do it here for
+            # demonstration purpose.
             hamming = dy.scalarInput(hamming_cost(predictions, reference))
             loss = prediction_score + hamming - reference_score
         else:

--- a/10-structured/bilstm-variant-tagger.py
+++ b/10-structured/bilstm-variant-tagger.py
@@ -232,8 +232,21 @@ def calc_sequence_score(scores, tags):
     return dy.esum([score[tag] for score, tag in zip(scores, tags)])
 
 
+def hamming_augmented_decode(scores, reference):
+    augmented_result = []
+    for score, referent_tag in zip(scores, reference):
+        origin_scores = score.npvalue()
+        cost = np.ones(origin_scores.shape)
+        cost[referent_tag] = 0
+        augmented_result.append(np.argmax(np.add(origin_scores, cost)))
+    return augmented_result
+
+
 def perceptron_loss(scores, reference):
-    predictions = [np.argmax(score.npvalue()) for score in scores]
+    if use_cost_augmented:
+        predictions = hamming_augmented_decode(scores, reference)
+    else:
+        predictions = [np.argmax(score.npvalue()) for score in scores]
 
     margin = dy.scalarInput(-2)
 


### PR DESCRIPTION
New examples include:
1. Teacher forcing
2. Perceptron loss
3. Hinge loss
4. Cost augmented (hamming cost) decoding
5. Scheduled sampling