### PR TITLE
Fixing issues #14 and #17

### DIFF
--- a/08-condlm/batched_enc_dec.py
+++ b/08-condlm/batched_enc_dec.py
@@ -158,13 +158,7 @@ def generate(sent):
     dy.renew_cg()
 
     # Transduce all batch elements with an LSTM
-    sent_reps = [LSTM_SRC.transduce([LOOKUP_SRC[x] for x in src])[-1] for src, trg in sents]
-
-    dy.renew_cg()
-
-    # Transduce all batch elements with an LSTM
-    src = sent[0]
-    trg = sent[1]
+    src = sent
 
 
     #initialize the LSTM
@@ -184,9 +178,9 @@ def generate(sent):
     for i in range(MAX_SENT_SIZE):
         #feed the previous word into the lstm, calculate the most likely word, add it to the sentence
         current_state = current_state.add_input(LOOKUP_TRG[prev_word])
-        output_embedding = hidden_state.output()
+        output_embedding = current_state.output()
         s = dy.affine_transform([b_sm, W_sm, output_embedding])
-        probs = -dy.log_softmax(s).value()
+        probs = (-dy.log_softmax(s)).value()
         next_word = np.argmax(probs)
 
         if next_word == eos_trg:
@@ -194,6 +188,7 @@ def generate(sent):
         prev_word = next_word
         trg_sent.append(i2w_trg[next_word])
     return trg_sent
+
 
 for ITER in range(100):
   # Perform training
@@ -216,6 +211,7 @@ for ITER in range(100):
   # Evaluate on dev set
   dev_words, dev_loss = 0, 0.0
   start = time.time()
+  print(generate(dev[0][0]))
   for sent_id, (start, length) in enumerate(dev_order):
     dev_batch = dev[start:start+length]
     my_loss, num_words = calc_loss(dev_batch)

--- a/08-condlm/enc_dec.py
+++ b/08-condlm/enc_dec.py
@@ -110,7 +110,6 @@ def calc_loss(sent):
 def generate(sent):
     dy.renew_cg()
 
-    # Transduce all batch elements with an LSTM
     src = sent
 
 
@@ -131,9 +130,9 @@ def generate(sent):
     for i in range(MAX_SENT_SIZE):
         #feed the previous word into the lstm, calculate the most likely word, add it to the sentence
         current_state = current_state.add_input(LOOKUP_TRG[prev_word])
-        output_embedding = hidden_state.output()
+        output_embedding = current_state.output()
         s = dy.affine_transform([b_sm, W_sm, output_embedding])
-        probs = -dy.log_softmax(s).value()
+        probs = (-dy.log_softmax(s)).value()
         next_word = np.argmax(probs)
 
         if next_word == eos_trg:

--- a/13-graphparsing/biaffine.py
+++ b/13-graphparsing/biaffine.py
@@ -119,7 +119,7 @@ class DeepBiaffineAttentionDecoder(object):
 
         # NOTE: should transpose before calling `mst` method!
         s_arc, s_label = self.cal_scores(src_encodings)
-        s_arc_values = s_arc.npvalue().transpose()  # src_len, src_len
+        s_arc_values = dy.softmax(s_arc).npvalue().transpose()  # src_len, src_len
         s_label_values = np.asarray([x.npvalue() for x in s_label]).transpose((2, 1, 0))  # src_len, src_len, n_labels
 
         # weights = np.zeros((src_len + 1, src_len + 1))

--- a/13-graphparsing/biaffine_parser.py
+++ b/13-graphparsing/biaffine_parser.py
@@ -27,7 +27,7 @@ def read(fname):
             sent = []
             labels = []
             heads = []
-            for i in range(num_tokens / 3):
+            for i in range(int(num_tokens / 3)):
                 sent.append(w2i[tokens[3 * i]])
                 labels.append(t2i[tokens[3 * i + 1]])
                 heads.append(int(tokens[3 * i + 2]))

--- a/13-graphparsing/mst.py
+++ b/13-graphparsing/mst.py
@@ -7,6 +7,9 @@ def mst(scores):
     Chu-Liu-Edmonds' algorithm for finding minimum spanning arborescence in graphs.
     Calculates the arborescence with node 0 as root.
     Source: https://github.com/chantera/biaffineparser/blob/master/utils.py
+    This is based off of the heuristics from the Stanford CoNLL 2017 parser, found here:
+
+    https://github.com/tdozat/Parser-v2/blob/master/parser/misc/mst.py
 
     :param scores: `scores[i][j]` is the weight of edge from node `i` to node `j`
     :returns an array containing the head node (node with edge pointing to current node) for each node,


### PR DESCRIPTION
#14, the encoder decoder now generates without bugs, and the other errors have been fixed.  

For #17 I added a softmax before we pass the values to the mst decoder, as this matches the Stanford parser and was simpler than changing the mst decoder.  This improves accuracy by ~4% through 5 iterations on dev, and there is no divide by zero warning on the first iteration, so it appears to have worked.

For the Chu-Liu-Edmonds MST vs. Stanford conll parser issue, I simply updated the comments to reflect the issue raised in #17.